### PR TITLE
remove inaccurate statement about VM-based blockchains

### DIFF
--- a/versioned_docs/version-0.50/learn/intro/01-why-app-specific.md
+++ b/versioned_docs/version-0.50/learn/intro/01-why-app-specific.md
@@ -60,7 +60,7 @@ The list above contains a few examples that show how much flexibility applicatio
 
 Decentralized applications built with Smart Contracts are inherently capped in performance by the underlying environment. For a decentralized application to optimise performance, it needs to be built as an application-specific blockchain. Next are some of the benefits an application-specific blockchain brings in terms of performance:
 
-* Developers of application-specific blockchains can choose to operate with a novel consensus engine such as CometBFT BFT. Compared to Proof-of-Work (used by most virtual-machine blockchains today), it offers significant gains in throughput.
+* Developers of application-specific blockchains can choose to operate with a novel consensus engine such as CometBFT BFT.
 * An application-specific blockchain only operates a single application, so that the application does not compete with others for computation and storage. This is the opposite of most non-sharded virtual-machine blockchains today, where smart contracts all compete for computation and storage.
 * Even if a virtual-machine blockchain offered application-based sharding coupled with an efficient consensus algorithm, performance would still be limited by the virtual-machine itself. The real throughput bottleneck is the state-machine, and requiring transactions to be interpreted by a virtual-machine significantly increases the computational complexity of processing them.
 


### PR DESCRIPTION
Most VM-based blockchains today now use PoS and not PoW