### PR TITLE
chore: fix typo in custom.css

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,5 +1,5 @@
 /*
-  Slighlty modified version of https://github.com/ignite/cli/blob/develop/docs/src/css/custom.css
+  Slightly modified version of https://github.com/ignite/cli/blob/develop/docs/src/css/custom.css
 */
 
 @import "tailwindcss/base";


### PR DESCRIPTION
# Fix: Corrected typo in CSS file

## Changes
- `src/css/custom.css:2`: "Slighlty" corrected to "Slightly".

## Purpose
- Improved CSS file accuracy and professionalism by fixing the typo.
