### PR TITLE
fix: verbatim text to escape mod

### DIFF
--- a/docs/build/building-apps/upgrades/0.52.md
+++ b/docs/build/building-apps/upgrades/0.52.md
@@ -213,7 +213,7 @@ plugins:
 
 ### Refactor Module Imports to cosmossdk.io/x/
 
-All modules except auth have been split into their own go.mod and are imported via cosmossdk.io/x/<mod>.
+All modules except auth have been split into their own go.mod and are imported via `cosmossdk.io/x/<mod>`.
 
 
 * Replace import paths from github.com/cosmos/cosmos-sdk/x/{moduleName} to cosmossdk.io/x/{moduleName}.


### PR DESCRIPTION
This commit simply wraps the path with the <mod> placeholder in backticks.
<mod> is otherwise read as a JSX tag and breaks the unified docsite as it is left open.