### PR TITLE
typo fix 03-txs.md

### DIFF
--- a/versioned_docs/version-0.50/user/run-node/03-txs.md
+++ b/versioned_docs/version-0.50/user/run-node/03-txs.md
@@ -269,7 +269,7 @@ func sendTx() error {
 
 ### Broadcasting a Transaction
 
-The preferred way to broadcast a transaction is to use gRPC, though using REST (via `gRPC-gateway`) or the CometBFT RPC is also posible. An overview of the differences between these methods is exposed [here](../../learn/advanced/06-grpc_rest.md). For this tutorial, we will only describe the gRPC method.
+The preferred way to broadcast a transaction is to use gRPC, though using REST (via `gRPC-gateway`) or the CometBFT RPC is also possible. An overview of the differences between these methods is exposed [here](../../learn/advanced/06-grpc_rest.md). For this tutorial, we will only describe the gRPC method.
 
 ```go
 import (


### PR DESCRIPTION
## Pull Request Title
fix: typo correction from "posible" to "possible"

### Description
This pull request corrects the typo in the documentation where "posible" was mistakenly used instead of the correct "possible."

### Changes Made
- Corrected the typo from "posible" to "possible."

### Related Issues
- N/A

### Additional Notes
- This small correction ensures the documentation is accurate and professional.
