### PR TITLE
fix: responsive DocSearch-Button 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -127,6 +127,9 @@ html {
       @media (min-width: 997px) {
         @apply w-auto justify-between;
       }
+      @media (max-width: 996px) {
+        @apply mr-7;
+      }
       .DocSearch-Search-Icon {
         @apply text-docusaurusColorBase;
       }


### PR DESCRIPTION
@julienrbrt 
I noticed an issue with the navbar layout when the screen is below 997px. At that point, the DocSearch-Button was overlapping with the hamburger menu as shown in the image below:
![image](https://github.com/user-attachments/assets/e4fa4e92-34e2-4cdc-8ad9-f35efc7b989e)
I have fixed it:
![image](https://github.com/user-attachments/assets/1b8ae619-91da-461f-9fc9-f8c033575101)
