### PR TITLE
fix: responsive layout for DocSearch-Button in different screen size [769px ->996px]->

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -127,7 +127,10 @@ html {
       @media (min-width: 997px) {
         @apply w-auto justify-between;
       }
-      @media (max-width: 996px) {
+      @media (min-width: 769px) and (max-width: 996px) {
+        @apply w-[80%] mr-7;
+      }
+      @media (max-width: 768px) {
         @apply mr-7;
       }
       .DocSearch-Search-Icon {
@@ -137,7 +140,7 @@ html {
         @apply hidden;
       }
       .DocSearch-Button-Placeholder {
-        @apply pr-10;
+        @apply pr-6 mr-5 ml-2; 
       }
     }
 


### PR DESCRIPTION
@aljo242 
I noticed an issue with the navbar layout when the screen width is between 769px and 997px. In this case, the background of the DocSearch-Button was not fully covering it and appeared misaligned, as shown in the image below:
![image](https://github.com/user-attachments/assets/7f845b19-e1e7-46c3-9e0c-a25129513c2e)
 So I have fixed it:
![image](https://github.com/user-attachments/assets/6bbb084f-cb78-412d-8dd9-e5f84ffe4356)
