### PR TITLE
ci: use actions/checkout@v5

### DIFF
--- a/.github/workflows/copy-md.yml
+++ b/.github/workflows/copy-md.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo $PR_BRANCH_NAME
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set Up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,7 +7,7 @@ jobs:
   test-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x


### PR DESCRIPTION
Upgrade to actions/checkout@v5 for improved performance and stability.

Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0